### PR TITLE
Ensure CloudWatch agent primary config is loaded only after deployment

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -28,16 +28,6 @@
     cloudwatch_log_stream_name: "{{ ansible_ec2_instance_id }}_{{ ansible_ec2_hostname }}"
     region: "{{ ansible_ec2_instance_identity_document_region }}"
 
-- name: Create CloudWatch agent primary configuration file
-  template:
-    src: templates/cloudwatch-config.json.j2
-    dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
-    trim_blocks: False
-
-- name: Start CloudWatch agent using primary configuration file
-  command:
-    cmd: "{{ cloudwatch_agent.path }} -a fetch-config -m ec2 -s -c file:{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
-
 - name: Using constructed variable suffixes
   ansible.builtin.debug:
     var: "{{ item }}"
@@ -79,6 +69,16 @@
   loop: "{{ tuxedo_service_users }}"
   loop_control:
     loop_var: tuxedo_user
+
+- name: Create CloudWatch agent primary configuration file
+  template:
+    src: templates/cloudwatch-config.json.j2
+    dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
+    trim_blocks: False
+
+- name: Start CloudWatch agent using primary configuration file
+  command:
+    cmd: "{{ cloudwatch_agent.path }} -a fetch-config -m ec2 -s -c file:{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
 
 - name: Find application-specific CloudWatch configuration files
   find:


### PR DESCRIPTION
This change mitigates the risk involved in reloading the primary CloudWatch configuration _before_ performing deployment tasks for one or more Tuxedo applications.

Previously, if a deployment task were to fail (i.e. any task in `deploy.yml`), the primary CloudWatch configuration would have been reloaded first (in `main.yml`), without any application-specific configurations appended to the running process (which occurred after `include_tasks` in `main.yml`). This would result in the CloudWatch agent only loading the primary configuration file and no longer pushing logs to AWS for ***all*** Tuxedo applications, and until such a time as the failure is resolved and the playbook run successfully to completion.

With theses change in place, any failure of the deployment tasks will not affect the existing CloudWatch agent process, which will continue to push log data for any previously loaded application configurations.