### PR TITLE
Remove template variable assertions

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -9,11 +9,6 @@
       - environment_name is defined and environment_name | trim | length > 0
       - application_artefact_path is defined and application_artefact_path | trim | length > 0
       - application_configs_path is defined and application_configs_path | trim | length > 0
-      - snmp_host_address is defined and snmp_host_address | trim | length > 0
-      - alpha_key_url is defined and alpha_key_url | trim | length > 0
-      - xbrl_validator_url is defined and xbrl_validator_url | trim | length > 0
-      - tnep_url is defined and tnep_url | trim | length > 0
-      - xslt_transformer_url is defined and xslt_transformer_url | trim | length > 0
     msg: "Required variable(s) empty or undefined"
 
 # The hostname is assumed to be in the format: frontend-tuxedo-<environment>-<instance-index>


### PR DESCRIPTION
These changes remove assertions that check for the presence of variables used to construct Tuxedo configuration files. These variables are passed to the Ansible process in the context of a pipeline and the assertions were previously added to avoid scenarios where templates could not be populated due to missing variables.

Given that there will be different requirements across Tuxedo services—hence different variables—the presence of these assertions imposes the need to statically define all variable expectations upfront. By removing these assertions we allow any `template` module task with variable expectations to fail instead. The failing task(s) will produce suitable error messages in the build log to indicate the missing variable(s).