### PR TITLE
Enabled access from live CEU FE cidrs

### DIFF
--- a/groups/frontend/instance.tf
+++ b/groups/frontend/instance.tf
@@ -122,6 +122,18 @@ resource "aws_security_group" "services" {
     }
   }
 
+  dynamic "ingress" {
+    for_each = each.key == "ceu" && var.environment == "live" ? each.value : {}
+    iterator = service
+    content {
+      description = "Allow client requests from Live CEU frontend to ${service.key} service in ${each.key} server group"
+      from_port   = service.value
+      to_port     = service.value
+      protocol    = "TCP"
+      cidr_blocks = local.ceu_live_fe_application_cidrs
+    }
+  }
+
   tags = merge(local.common_tags, {
     Name             = "${each.key}-${local.common_resource_name}"
     TuxedoServerType = each.key

--- a/groups/frontend/locals.tf
+++ b/groups/frontend/locals.tf
@@ -70,4 +70,6 @@ locals {
   logs_kms_key_id = data.vault_generic_secret.kms_keys.data["logs"]
 
   chs_application_cidrs = values(data.vault_generic_secret.chs_application_cidrs.data)
+
+  ceu_live_fe_application_cidrs = var.environment == "live" ? jsondecode(data.vault_generic_secret.ceu_live_fe_outputs[0].data["ceu-frontend-web-subnets-cidrs"]) : []
 }

--- a/groups/frontend/secrets.tf
+++ b/groups/frontend/secrets.tf
@@ -17,3 +17,8 @@ data "vault_generic_secret" "tns_names" {
 data "vault_generic_secret" "chs_application_cidrs" {
   path = "aws-accounts/network/${var.aws_account}/chs/application-subnets"
 }
+
+data "vault_generic_secret" "ceu_live_fe_outputs" {
+  count = var.environment == "live" ? 1 : 0
+  path = "applications/pci-services-${var.region}/ceu/ceu-fe-outputs"
+}


### PR DESCRIPTION
Added new data source to gather CEU FE data from vault when running in live
Added local var to extract CIDRs from vault data
Added new dynamic `ingress` block to permit CEU FE CIDRs access when the service is `ceu` and running in live