### PR TITLE
Improve log rotation

### DIFF
--- a/roles/deploy/templates/logrotate.tuxedo.conf.j2
+++ b/roles/deploy/templates/logrotate.tuxedo.conf.j2
@@ -15,7 +15,6 @@
   daily
   copytruncate
   compress
-  maxage 93
   maxsize 1800M
   missingok
   notifempty
@@ -23,6 +22,7 @@
   rotate 20
   createolddir 0755 root root
   lastaction
-    /bin/find /var/log/tuxedo -maxdepth 2 -name 'ULOG.*' -mtime +1 -size 0 -delete
+    /bin/find {{ tuxedo_logs_path }} -name 'ULOG*.gz' -mtime +93 -exec rm -f {} \;
+    /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'ULOG.*' -not -name "ULOG.$(date +%m%d%y)" -size 0 -delete
   endscript
 }


### PR DESCRIPTION
Improvements to log rotation and retention:

* Remove rotated `ULOG` files older than 93 days
* Remove empty (i.e. already truncated) logs for any previous day excluding today