### PR TITLE
Remove temporary security group rules for on-premise frontends

### DIFF
--- a/groups/frontend/instance.tf
+++ b/groups/frontend/instance.tf
@@ -85,19 +85,6 @@ resource "aws_security_group" "services" {
     }
   }
 
-  # TODO Remove this; this was added for testing Tuxedo services in live using on-premise frontend services
-  dynamic "ingress" {
-    for_each = var.environment == "live" || var.environment == "staging" ? each.value : {}
-    iterator = service
-    content {
-      description = "Allow client requests from on-premise frontend web servers to ${service.key} service in ${each.key} server group"
-      from_port   = service.value
-      to_port     = service.value
-      protocol    = "TCP"
-      cidr_blocks = var.on_premise_frontend_cidrs
-    }
-  }
-
   dynamic "ingress" {
     for_each = each.value
     iterator = service

--- a/groups/frontend/variables.tf
+++ b/groups/frontend/variables.tf
@@ -82,13 +82,6 @@ variable "lvm_block_devices" {
   default = []
 }
 
-# TODO Remove this; this was added for testing Tuxedo services in live using on-premise frontend services
-variable "on_premise_frontend_cidrs" {
-  type        = list(string)
-  description = "A list of strings representing the CIDR ranges for on-premise frontend services"
-  default     = []
-}
-
 variable "region" {
   type        = string
   description = "The AWS region in which resources will be administered"


### PR DESCRIPTION
⚠️ **Not to be merged until all frontend services have been migrated to AWS**

Resolves: `DVOP-1852`