### PR TITLE
Syntax improvements and state reconciliation

### DIFF
--- a/groups/frontend/instance.tf
+++ b/groups/frontend/instance.tf
@@ -81,7 +81,7 @@ resource "aws_security_group" "services" {
       from_port   = service.value
       to_port     = service.value
       protocol    = "TCP"
-      cidr_blocks = data.aws_subnet.web.*.cidr_block
+      cidr_blocks = data.aws_subnet.web[*].cidr_block
     }
   }
 
@@ -106,7 +106,7 @@ resource "aws_security_group" "services" {
       from_port   = service.value
       to_port     = service.value
       protocol    = "TCP"
-      cidr_blocks = data.aws_subnet.application.*.cidr_block
+      cidr_blocks = data.aws_subnet.application[*].cidr_block
     }
   }
 
@@ -174,7 +174,7 @@ resource "aws_security_group" "common" {
     from_port   = 38200
     to_port     = 38200
     protocol    = "TCP"
-    cidr_blocks = flatten([[var.chips_cidr], data.aws_subnet.application.*.cidr_block])
+    cidr_blocks = flatten([[var.chips_cidr], data.aws_subnet.application[*].cidr_block])
   }
 
   ingress {
@@ -182,7 +182,7 @@ resource "aws_security_group" "common" {
     from_port   = 38300
     to_port     = 38300
     protocol    = "TCP"
-    cidr_blocks = flatten([[var.chips_cidr], data.aws_subnet.application.*.cidr_block])
+    cidr_blocks = flatten([[var.chips_cidr], data.aws_subnet.application[*].cidr_block])
   }
 
   egress {
@@ -222,7 +222,7 @@ resource "aws_instance" "frontend" {
       encrypted   = block_device.value.ebs.encrypted
       iops        = block_device.value.ebs.iops
       snapshot_id = block_device.value.ebs.snapshot_id
-      volume_size = var.lvm_block_devices[index(var.lvm_block_devices.*.lvm_physical_volume_device_node, block_device.value.device_name)].aws_volume_size_gb
+      volume_size = var.lvm_block_devices[index(var.lvm_block_devices[*].lvm_physical_volume_device_node, block_device.value.device_name)].aws_volume_size_gb
       volume_type = block_device.value.ebs.volume_type
     }
   }

--- a/groups/frontend/locals.tf
+++ b/groups/frontend/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  application_subnet_ids_by_az = values(zipmap(data.aws_subnet.application.*.availability_zone, data.aws_subnet.application.*.id))
+  application_subnet_ids_by_az = values(zipmap(data.aws_subnet.application[*].availability_zone, data.aws_subnet.application[*].id))
 
   common_tags = {
     Environment    = var.environment
@@ -30,8 +30,8 @@ locals {
   tuxedo_service_log_groups = merge([
     for tuxedo_service_key, tuxedo_logs_list in var.tuxedo_service_logs : {
       for tuxedo_log in setproduct(tuxedo_logs_list[*].name, ["stdout", "stderr"]) : "${var.service_subtype}-${var.service}-${tuxedo_service_key}-${lower(tuxedo_log[0])}-${tuxedo_log[1]}" => {
-        log_retention_in_days = lookup(tuxedo_logs_list[index(tuxedo_logs_list.*.name, tuxedo_log[0])], "log_retention_in_days", var.default_log_retention_in_days)
-        kms_key_id = lookup(tuxedo_logs_list[index(tuxedo_logs_list.*.name, tuxedo_log[0])], "kms_key_id", local.logs_kms_key_id)
+        log_retention_in_days = lookup(tuxedo_logs_list[index(tuxedo_logs_list[*].name, tuxedo_log[0])], "log_retention_in_days", var.default_log_retention_in_days)
+        kms_key_id = lookup(tuxedo_logs_list[index(tuxedo_logs_list[*].name, tuxedo_log[0])], "kms_key_id", local.logs_kms_key_id)
         tuxedo_service = tuxedo_service_key
         log_name = tuxedo_log[0]
         log_type = tuxedo_log[1]
@@ -40,12 +40,12 @@ locals {
   ]...)
 
   tuxedo_user_log_groups = merge([
-    for tuxedo_service_key, tuxedo_logs_list in var.tuxedo_user_logs : {
-      for tuxedo_log in tuxedo_logs_list[*].name : "${var.service_subtype}-${var.service}-${tuxedo_service_key}-${lower(tuxedo_log)}" => {
-        log_retention_in_days = lookup(tuxedo_logs_list[index(tuxedo_logs_list.*.name, tuxedo_log)], "log_retention_in_days", var.default_log_retention_in_days)
-        kms_key_id = lookup(tuxedo_logs_list[index(tuxedo_logs_list.*.name, tuxedo_log)], "kms_key_id", local.logs_kms_key_id)
+    for tuxedo_service_key, tuxedo_user_logs_list in var.tuxedo_user_logs : {
+      for tuxedo_user_log in tuxedo_user_logs_list : "${var.service_subtype}-${var.service}-${tuxedo_service_key}-${lower(tuxedo_user_log.name)}" => {
+        log_retention_in_days = lookup(tuxedo_user_log, "log_retention_in_days", var.default_log_retention_in_days)
+        kms_key_id = lookup(tuxedo_user_log, "kms_key_id", local.logs_kms_key_id)
         tuxedo_service = tuxedo_service_key
-        log_name = tuxedo_log
+        log_name = tuxedo_user_log.name
         log_type = "individual"
       }
     }
@@ -53,11 +53,11 @@ locals {
 
   tuxedo_ngsrv_log_groups = merge([
     for tuxedo_service_key, ngsrv_logs_list in var.tuxedo_ngsrv_logs : {
-      for ngsrv_log in ngsrv_logs_list[*].name : "${var.service_subtype}-${var.service}-${tuxedo_service_key}-ngsrv-${lower(ngsrv_log)}" => {
-        log_retention_in_days = lookup(ngsrv_logs_list[index(ngsrv_logs_list.*.name, ngsrv_log)], "log_retention_in_days", var.default_log_retention_in_days)
-        kms_key_id = lookup(ngsrv_logs_list[index(ngsrv_logs_list.*.name, ngsrv_log)], "kms_key_id", local.logs_kms_key_id)
+      for ngsrv_log in ngsrv_logs_list : "${var.service_subtype}-${var.service}-${tuxedo_service_key}-ngsrv-${lower(ngsrv_log.name)}" => {
+        log_retention_in_days = lookup(ngsrv_log, "log_retention_in_days", var.default_log_retention_in_days)
+        kms_key_id = lookup(ngsrv_log, "kms_key_id", local.logs_kms_key_id)
         tuxedo_service = tuxedo_service_key
-        log_name = ngsrv_log
+        log_name = ngsrv_log.name
       }
     }
   ]...)

--- a/groups/frontend/variables.tf
+++ b/groups/frontend/variables.tf
@@ -219,22 +219,22 @@ variable "tuxedo_user_logs" {
   description = "A map whose keys represent server-side tuxedo server groups with lists of objects representing individual log files for each server group. Each object is expected to have at a minimum a 'name' key. A single CloudWatch log group will be created for each object. Optional 'log_retention_in_days' and 'kms_key_id' attributes can be set per-file to override the default values."
   default = {
     ceu = [
-      { name: "ULOG" }
+      { name = "ULOG", log_retention_in_days: 7 }
     ]
     chd = [
-      { name: "ULOG" }
+      { name = "ULOG", log_retention_in_days: 7 }
     ]
     ewf = [
-      { name: "ULOG" }
+      { name = "ULOG", log_retention_in_days: 14  }
     ]
     xml = [
-      { name: "ULOG" }
+      { name = "ULOG", log_retention_in_days: 7  }
     ]
     wck = [
-      { name: "ULOG" }
+      { name = "ULOG", log_retention_in_days: 7  }
     ]
     chs = [
-      { name: "ULOG" }
+      { name = "ULOG", log_retention_in_days: 7  }
     ]
   }
 }


### PR DESCRIPTION
These changes include the following fixes:

* Replace legacy "attribute-only" splat expressions with new syntax (i.e. `[*]`)
* Simplify complex data structure conversion in `locals.tf`, and introduce a workaround for a Terraform bug that affects log group retention (fixed in `0.15.0+`) which requires an explicit `log_retention_in_days` period for each log group