### PR TITLE
Use canonical YAML truthy values

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-host_key_checking = False
+host_key_checking = false
 timeout = 60
 
 [inventory]

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,4 +6,4 @@ timeout = 60
 enable_plugins = aws_ec2
 
 [ssh_connection]
-pipelining = True
+pipelining = true

--- a/deploy.yml
+++ b/deploy.yml
@@ -12,6 +12,6 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: deploy

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -177,7 +177,7 @@
   template:
     src: templates/cloudwatch-config-service.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config-{{ tuxedo_user }}.json"
-    trim_blocks: False
+    trim_blocks: false
 
 - name: "{{ tuxedo_user }} : Start Tuxedo services"
   become_user: "{{ tuxedo_user }}"

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -3,7 +3,7 @@
 - name: Retrieve service-specific database credentials from Hashicorp Vault
   set_fact:
     "{{ item }}_db_credentials": "{{ lookup('community.hashi_vault.hashi_vault', 'applications/heritage-{{ environment_name }}-eu-west-2/chl-tuxedo/database/{{ item }}') }}"
-  no_log: True
+  no_log: true
   loop: "{{ tuxedo_service_config[tuxedo_user].required_databases | default([]) }}"
 
 - name: Set database credential variables for template population
@@ -11,7 +11,7 @@
     "{{ item }}_database_password": "{{ vars[item + '_db_credentials']['database_password'] }}"
     "{{ item }}_database_username": "{{ vars[item + '_db_credentials']['database_username'] }}"
     "{{ item }}_database_tns_name": "{{ vars[item + '_db_credentials']['database_tns_name'] }}"
-  no_log: True
+  no_log: true
   loop: "{{ tuxedo_service_config[tuxedo_user].required_databases | default([]) }}"
 
 - name: Set Tuxedo ID prefix variable for template population
@@ -32,7 +32,7 @@
     tuxedo_logical_machine_id: "{{ tuxedo_id_prefix }}_{{ tuxedo_logical_machine_id_suffix }}"
     tuxedo_machine_name: "{{ ansible_facts.hostname }}"
     tuxedo_user_id: "{{ getent_passwd[tuxedo_user][getent_uid_index] }}"
-  no_log: True
+  no_log: true
 
 - name: "{{ tuxedo_user }} : Create temporary directory for new {{ tuxedo_user }} deployment"
   become_user: "{{ tuxedo_user }}"
@@ -61,7 +61,7 @@
     mode: 0644
   with_fileglob:
     - "{{ application_configs_path }}/{{ tuxedo_user }}/*.j2"
-  no_log: True
+  no_log: true
 
 - name: "{{ tuxedo_user }} : Find idx files for service"
   find:
@@ -85,7 +85,7 @@
     path: "{{ new_deployment_files.path }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    recurse: yes
+    recurse: true
 
 - name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} current deployment directory"
   stat:
@@ -97,7 +97,7 @@
   shell: "source {{ tuxedo_env_file_path }} && ngsrv.sh stop"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: current_deployment_files.stat.exists
 
 - name: "{{ tuxedo_user }} : Stop Tuxedo services"
@@ -105,7 +105,7 @@
   shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: current_deployment_files.stat.exists
 
 - name: "{{ tuxedo_user }} : Clear IPC facilities"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -99,7 +99,7 @@
   template:
     src: templates/cloudwatch-config.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
-    trim_blocks: False
+    trim_blocks: false
 
 - name: Start CloudWatch agent using primary configuration file
   command:

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -53,7 +53,7 @@
   unarchive:
     src: "{{ application_artifact_path }}"
     dest: "{{ application_artifact_files.path }}"
-    remote_src: no
+    remote_src: false
     owner: root
     group: "{{ tuxedo_service_group }}"
     mode: 0755


### PR DESCRIPTION
These changes ensure that truthy values are represented using canonical [YAML boolean form](https://yaml.org/spec/1.2.1/#id2803629) in accordance with recent [Ansible documentation updates](https://github.com/ansible/ansible/pull/78429) and will suppress `yamllint` warnings.