### PR TITLE
Fix for system logrotate cron

### DIFF
--- a/roles/deploy/tasks/cron.yml
+++ b/roles/deploy/tasks/cron.yml
@@ -8,7 +8,7 @@
     hour: "*"
     user: "root"
     job: "/sbin/logrotate {{ tuxedo_log_rotation_config_path }}"
-    cron_file: /etc/crontab
+    cron_file: /etc/cron.d/log-rotation
 
 - name: Create maintenance job for periodic mail spool truncation
   ansible.builtin.cron:


### PR DESCRIPTION
This change ensures that the `logrotate` system cron job exists outside of the `/etc/crontab` file which the Ansible `cron` module will refuse to manage. This is consistent with how the job is managed in other Tuxedo stacks.