### PR TITLE
Remove load balancer specific ingress rules

### DIFF
--- a/groups/frontend/data.tf
+++ b/groups/frontend/data.tf
@@ -89,20 +89,6 @@ data "cloudinit_config" "config" {
   }
 }
 
-data "aws_network_interface" "nlb" {
-  for_each = toset(data.aws_subnets.application.ids)
-
-  filter {
-    name   = "description"
-    values = ["ELB ${aws_lb.frontend.arn_suffix}"]
-  }
-
-  filter {
-    name   = "subnet-id"
-    values = [each.value]
-  }
-}
-
 data "vault_generic_secret" "kms_keys" {
   path = "aws-accounts/${var.aws_account}/kms"
 }

--- a/groups/frontend/instance.tf
+++ b/groups/frontend/instance.tf
@@ -20,16 +20,6 @@ resource "aws_security_group" "services" {
   })
 }
 
-resource "aws_vpc_security_group_ingress_rule" "lb_health_check_ingress" {
-  for_each = local.lb_health_check_ingress_rules
-
-  security_group_id = aws_security_group.services[each.value.group].id
-  description       = "Allow health check requests from network load balancer to ${upper(each.value.service)} service in ${upper(each.value.group)} server group"
-  cidr_ipv4         = each.value.cidr_ipv4
-  from_port         = each.value.port
-  to_port           = each.value.port
-  ip_protocol       = "tcp"
-}
 
 resource "aws_vpc_security_group_ingress_rule" "frontend_web_ingress" {
   for_each = local.frontend_web_ingress_rules
@@ -46,7 +36,7 @@ resource "aws_vpc_security_group_ingress_rule" "backend_ingress" {
   for_each = local.backend_ingress_rules
 
   security_group_id = aws_security_group.services[each.value.group].id
-  description       = "Allow client requests from backend servers to ${upper(each.value.service)} service in ${upper(each.value.group)} server group"
+  description       = "Allow client requests from backend servers or network load balancers to ${upper(each.value.service)} service in ${upper(each.value.group)} server group"
   cidr_ipv4         = each.value.cidr_ipv4
   from_port         = each.value.port
   to_port           = each.value.port

--- a/groups/frontend/locals.tf
+++ b/groups/frontend/locals.tf
@@ -87,12 +87,6 @@ locals {
     }
   ]...)
 
-  lb_health_check_ingress_rules = merge([
-    for cidr_block in formatlist("%s/32", [for eni in data.aws_network_interface.nlb : eni.private_ip]) : {
-      for service_and_group_name, config in local.all_services : "${service_and_group_name}-${cidr_block}" => merge(config, { cidr_ipv4 = cidr_block })
-    }
-  ]...)
-
   frontend_web_ingress_rules = merge([
     for cidr_block in data.aws_subnet.web[*].cidr_block : {
       for service_and_group_name, config in local.all_services : "${service_and_group_name}-${cidr_block}" => merge(config, { cidr_ipv4 = cidr_block })


### PR DESCRIPTION
This change removes redundant `/32` ingress rules for the network load balancer which are already covered by ingress rules for the application subnets. This also resolves an issue whereby map keys are derived from values only known at apply time.