### PR TITLE
Enable ELB deletion protection

### DIFF
--- a/groups/frontend/variables.tf
+++ b/groups/frontend/variables.tf
@@ -57,7 +57,7 @@ variable "instance_type" {
 variable "lb_deletion_protection" {
   type        = bool
   description = "A boolean value representing whether to enable load balancer deletion protection"
-  default     = false
+  default     = true
 }
 
 variable "lvm_block_devices" {


### PR DESCRIPTION
Updated default value of lb_deletion_protection to true in line with an action from a recent ITHC security audit mandating LB deletion protection being enabled.