### PR TITLE
Increase default log retention period

### DIFF
--- a/groups/frontend/profiles/heritage-live-eu-west-2/live/vars
+++ b/groups/frontend/profiles/heritage-live-eu-west-2/live/vars
@@ -8,20 +8,4 @@ instance_type = "m5.large"
 
 root_volume_size = 100
 
-tuxedo_user_log_groups = {
-  ceu = [
-    { name = "ULOG", log_retention_in_days: 7 }
-  ]
-  chd = [
-    { name = "ULOG", log_retention_in_days: 7 }
-  ]
-  ewf = [
-    { name = "ULOG", log_retention_in_days: 14 }
-  ]
-  xml = [
-    { name = "ULOG", log_retention_in_days: 7 }
-  ]
-  chs = [
-    { name = "ULOG", log_retention_in_days: 7 }
-  ]
-}
+default_log_retention_in_days = 90

--- a/groups/frontend/variables.tf
+++ b/groups/frontend/variables.tf
@@ -28,7 +28,7 @@ variable "chips_cidr" {
 variable "default_log_retention_in_days" {
   type        = number
   description = "The default log retention period in days to be used for CloudWatch log groups."
-  default     = 7
+  default     = 30
 }
 
 variable "dns_zone_suffix" {


### PR DESCRIPTION
This update sets a default log retention period of `30` days for log groups in the `development` and `staging` environments, and `90` days for those in the `live` environment.

Resolves: `DVOP-4503`,